### PR TITLE
Moved the help files into an external resource 

### DIFF
--- a/mainWindow/cwe_mainwindow.cpp
+++ b/mainWindow/cwe_mainwindow.cpp
@@ -56,7 +56,7 @@ CWE_MainWindow::CWE_MainWindow(QWidget *parent) :
 
 #ifdef Q_OS_WIN
     // whoever compiles on Windows: your path here
-    QResource::registerResource("C:\Users\pmackenz\Development\SimCenter\CFDClientProgram\resources\cwe_help.rcc");
+    QResource::registerResource("C:/Users/Peter Mackenzie/Documents/GitHub/CFDClientProgram/resources/cwe_help.rcc");
 #endif
 
 #ifdef Q_OS_LINUX

--- a/mainWindow/cwe_mainwindow.cpp
+++ b/mainWindow/cwe_mainwindow.cpp
@@ -42,11 +42,28 @@
 #include "../AgaveClientInterface/remotedatainterface.h"
 #include "cwe_globals.h"
 #include <QResource>
+#include <QDebug>
 
 CWE_MainWindow::CWE_MainWindow(QWidget *parent) :
     QMainWindow(parent),
     ui(new Ui::CWE_MainWindow)
 {
+    // register binary resources
+#ifdef Q_OS_MAC
+    // Peter MH: your path here
+    QResource::registerResource("/Users/pmackenz/Development/SimCenter/CFDClientProgram/resources/cwe_help.rcc");
+#endif
+
+#ifdef Q_OS_WIN
+    // whoever compiles on Windows: your path here
+    QResource::registerResource("C:\Users\pmackenz\Development\SimCenter\CFDClientProgram\resources\cwe_help.rcc");
+#endif
+
+#ifdef Q_OS_LINUX
+    // Peter S: your path here
+    QResource::registerResource("/Users/pmackenz/Development/SimCenter/CFDClientProgram/resources/cwe_help.rcc");
+#endif
+
     ui->setupUi(this);
 
     changeParamsAndResultsEnabled(false);
@@ -56,9 +73,6 @@ CWE_MainWindow::CWE_MainWindow(QWidget *parent) :
 
     changeTabEnabled(ui->tab_spacer_1, false);
     changeTabEnabled(ui->tab_spacer_2, false);
-
-    // register binary resources
-    QResource::registerResource("/resources/cwe_help.rcc");
 
     // adjust application size to display
     QRect rec = QApplication::desktop()->screenGeometry();


### PR DESCRIPTION
The resource is located in 
./CFDClientProgram/resources/cwe_help.rcc

It turns out the binary version is compatible between MacOS and Windows 10.  
Needs to be verified on linux, though.